### PR TITLE
Use Bearer token headers & add zbxVersionContraint functionality

### DIFF
--- a/hosts_test.go
+++ b/hosts_test.go
@@ -126,6 +126,7 @@ func TestHostsGet(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	hosts, err := zabbix.GetHosts(Params{})
 
@@ -151,6 +152,7 @@ func TestHostsRemove(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	var hostids Hosts
 	payload := []string{"13", "32"}

--- a/maintenances_test.go
+++ b/maintenances_test.go
@@ -89,6 +89,7 @@ func TestMaintenanceGet(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	maintenances, err := zabbix.GetMaintenances(Params{
 		"search": Params{
@@ -117,6 +118,7 @@ func TestMaintenanceRemove(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	payload := []string{"3", "1"}
 
@@ -143,6 +145,7 @@ func TestMaintenanceCreate(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	var timeperiod Timeperiod
 

--- a/zabbix_issue18_test.go
+++ b/zabbix_issue18_test.go
@@ -171,6 +171,7 @@ func TestIssue18(t *testing.T) {
 	zabbix := &Zabbix{}
 	zabbix.client = testserver.Client()
 	zabbix.apiURL = testserver.URL
+	zabbix.apiVersion = "5.0.0"
 
 	items, err := zabbix.GetItems(Params{"hostids": []string{"10084"}})
 	test.NoError(err)


### PR DESCRIPTION
Add: zbxVersionContraint function to allow for easily checking required Zabbix API versions
Fix: Use Bearer token header instead of auth parameter from Zabbix >=6.4.0
Fix: add apiVersion to test cases

Solves #12 